### PR TITLE
[Feat] Google Maps 연동 및 지도 생성 

### DIFF
--- a/capstone/public/index.html
+++ b/capstone/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Capstone Project</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -1,19 +1,45 @@
-import { useState, useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 function App() {
-  const [message, setMessage] = useState("");
+  const mapRef = useRef(null);
 
   useEffect(() => {
-    fetch("http://localhost:8080/api/hello") // Spring Boot API 호출
-      .then((response) => response.text()) // 문자열 반환이므로 .text() 사용
-      .then((data) => setMessage(data)) // 상태 업데이트
-      .catch((error) => console.error("Error fetching data:", error));
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}`;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      const inhaUniversity = { lat: 37.45, lng: 126.6535 };
+
+      const map = new window.google.maps.Map(mapRef.current, {
+        center: inhaUniversity,
+        zoom: 16,
+        mapTypeControl: true,
+        fullscreenControl: true,
+      });
+
+      new window.google.maps.Marker({
+        position: inhaUniversity,
+        map,
+        title: "Inha University",
+      });
+    };
+
+    document.head.appendChild(script);
   }, []);
 
   return (
     <div>
-      <h1>React & Spring Boot 연결 테스트</h1>
-      <p>Spring Boot 응답: {message}</p>
+      <h1 style={{ textAlign: "center" }}>인하대학교 중심으로 지도 생성</h1>
+      <div
+        ref={mapRef}
+        style={{
+          width: "100%",
+          height: "600px",
+          margin: "0 auto",
+          border: "2px solid #ccc",
+        }}
+      ></div>
     </div>
   );
 }

--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -1,35 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState, useEffect } from "react";
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    fetch("http://localhost:8080/api/hello") // Spring Boot API 호출
+      .then((response) => response.text()) // 문자열 반환이므로 .text() 사용
+      .then((data) => setMessage(data)) // 상태 업데이트
+      .catch((error) => console.error("Error fetching data:", error));
+  }, []);
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div>
+      <h1>React & Spring Boot 연결 테스트</h1>
+      <p>Spring Boot 응답: {message}</p>
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Capstone-Web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### 📝 작업 내용

1. Google Maps API를 React 프로젝트에 연동
   - 초기 중심 좌표: 인하대학교 (위도: 37.45, 경도: 126.6535)
   - 마커 1개 추가 (인하대)

2. API Key 보안 처리
   - 구글 지도 로딩
   - .env에 Google Maps API Key 추가

### ✅ 테스트

- React 실행 시, 로컬 서버에서 지도 확인
- 지도에 인하대학교 중심으로 위치 설정 및 마커 정상 출력 확인

![지도생성완료](https://github.com/user-attachments/assets/6636cfd0-32aa-447f-89bf-5ccb34477b4e)


### 💬 다음 단계

- 백엔드 API 연동하여 여러 출입구 좌표 받아오기
- 지도 위에 마커 여러 개 표시 (DB → React)