### PR TITLE
[Feat]: Spring API에서 받은 출입구 좌표 지도 위에 마커로 표시

### DIFF
--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -1,44 +1,53 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function App() {
   const mapRef = useRef(null);
+  const [map, setMap] = useState(null);
 
   useEffect(() => {
     const script = document.createElement("script");
     script.src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}`;
     script.async = true;
     script.defer = true;
+
     script.onload = () => {
-      const inhaUniversity = { lat: 37.45, lng: 126.6535 };
-
-      const map = new window.google.maps.Map(mapRef.current, {
-        center: inhaUniversity,
+      const center = { lat: 37.45, lng: 126.6535 };
+      const mapObj = new window.google.maps.Map(mapRef.current, {
+        center,
         zoom: 16,
-        mapTypeControl: true,
-        fullscreenControl: true,
       });
 
-      new window.google.maps.Marker({
-        position: inhaUniversity,
-        map,
-        title: "Inha University",
-      });
+      setMap(mapObj); 
     };
 
     document.head.appendChild(script);
   }, []);
 
+  useEffect(() => {
+    if (!map) return;
+
+    fetch("http://localhost:8080/api/gate-points")
+      .then((res) => res.json())
+      .then((data) => {
+        data.forEach((point) => {
+          const marker = new window.google.maps.Marker({
+            position: { lat: point.latitude, lng: point.longitude },
+            map: map,
+            title: `Gate ${point.id}`,
+          });
+        });
+      })
+      .catch((error) => {
+        console.error("Error loading gate points:", error);
+      });
+  }, [map]);
+
   return (
     <div>
-      <h1 style={{ textAlign: "center" }}>인하대학교 중심으로 지도 생성</h1>
+      <h1>인하대학교 출입구 지도</h1>
       <div
         ref={mapRef}
-        style={{
-          width: "100%",
-          height: "600px",
-          margin: "0 auto",
-          border: "2px solid #ccc",
-        }}
+        style={{ width: "100%", height: "600px", border: "1px solid #ccc" }}
       ></div>
     </div>
   );


### PR DESCRIPTION
### 📝 작업 내용
1. Spring API 연동
   - `GET http://localhost:8080/api/gate-points` 호출
   - 응답받은 좌표 데이터를 기반으로 Google Map에 마커 13개 동적 렌더링

2. 마커 렌더링 로직
   - 지도 초기화 후 API 호출
   - 받아온 좌표 배열을 통해 마커 생성
   
### ✅ 테스트
React 실행 시, 로컬 서버에서 지도 확인
지도에 인하대학교 중심으로 위치 설정 및 마커 정상 출력 확인
![디비에서받아온사진](https://github.com/user-attachments/assets/806394ef-c45f-4ee0-ba87-96f30a9e4a3f)
