### PR TITLE
[Feat] React에서 도로 중심 좌표 API 연동 및 지도 마커 표시 기능 추가

### DIFF
--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -23,6 +23,7 @@ function App() {
     document.head.appendChild(script);
   }, []);
 
+  // 건물 출입구 마커 표시 관련 코드
   useEffect(() => {
     if (!map) return;
 
@@ -39,6 +40,29 @@ function App() {
       })
       .catch((error) => {
         console.error("Error loading gate points:", error);
+      });
+  }, [map]);
+
+  // 도로 중심 마커 표시 관련 코드 
+  useEffect(() => {
+    if (!map) return;
+
+    fetch("http://localhost:8080/api/road-centers")
+      .then((res) => res.json())
+      .then((data) => {
+        data.forEach((center) => {
+          new window.google.maps.Marker({
+            position: { lat: center.latitude, lng: center.longitude },
+            map: map,
+            title: `도로 중심점 ${center.id}`,
+            icon: {
+              url: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png", // 건물 출입구랑 안겹치게 파란 마커 사용 
+            },
+          });
+        });
+      })
+      .catch((error) => {
+        console.error("Error loading road centers:", error);
       });
   }, [map]);
 


### PR DESCRIPTION
###  작업 내용
1. React 에서 GET /api/road-centers API 호출 로직 추가
 - fetch()를 통해 도로 중심 좌표 데이터를 비동기로 받아옴

2. 응답받은 좌표들을 Google Maps 상에 마커로 표시 
 - 기존 출입구 마커와 구분되도록 파란색 마커 사용하여 색깔 구분 

###  테스트 결과
앱 실행 시 도로 중심 좌표들 정상적으로 API에서 불러와짐

Google Maps 상에서 파란색 마커로 구분되어 표시됨

기존 출입구 마커와 겹치지 않고, 지도에 동시 표시 가능

CORS 및 API 통신 문제 없음 (http://localhost:8080/api/road-centers 확인 완료)
![테스트](https://github.com/user-attachments/assets/b7f98b38-ee68-41eb-ba84-eb6adc8711c1)


### 다음 단계
간단한 css 및 line을 어떻게 표시하고 처리할지 고민중 


