### PR TITLE
[Feat]: Flask 기반 실시간 GNSS 위치 시각화 서버 및 템플릿 추가

### DIFF
--- a/Flask_GPS/gnss.html
+++ b/Flask_GPS/gnss.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>실시간 GNSS 지도</title>
+    
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+
+    <style>
+        #map { height: 500px; width: 100%; }
+    </style>
+</head>
+<body>
+    <h1>실시간 GNSS 지도</h1>
+    <div id="map"></div>
+
+    <script>
+        // 1️⃣ Leaflet을 사용하여 지도 생성
+        var map = L.map('map').setView([37.5665, 126.9780], 13);
+
+        // 2️⃣ OpenStreetMap 타일 추가
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+
+        // 3️⃣ 추정된 GPS 좌표를 사용해 마커 생성
+        var marker;
+
+        function  getData() {
+            fetch("https://inhamap.n-e.kr/gps",{
+                method: "GET"
+            })
+            .then(response => response.json())
+            .then(data => {
+                // 추정된 좌표가 서버에서 받아졌을 때
+                if (data.status === "success") {
+                    let Lat = data.latitude;
+                    let Lon = data.longitude;
+                    let snr = data.snr;
+
+                    console.log("📌 GPS 데이터:", Lat, Lon, snr);
+
+                    // 6️⃣ 추정된 GPS 좌표로 마커 위치 업데이트
+                    updateMarker(Lat, Lon, snr);
+                }
+                else{
+                    updateLocation();
+                }
+            })
+            .catch(error => console.error("❌ 에러 발생:", error));  
+        }
+
+        function updateMarker(lat, lon,snr) {
+            let markerColor = getColorBySNR(snr);
+            if (marker) {
+                // 기존 마커가 있으면 위치 업데이트
+                marker.setLatLng([lat, lon]).setIcon(createMarkerIcon(markerColor));
+            } else {
+                // 없으면 새로운 마커 추가
+                marker = L.marker([lat, lon], { icon: createMarkerIcon(markerColor) }).addTo(map);
+            }
+            map.setView([lat, lon], 13);  // 지도 중심을 추정된 좌표로 설정
+        }
+
+        function getColorBySNR(snr) {
+            if (snr >= 40) return "green";
+            if (snr >= 30) return "orange";
+            if (snr >= 20) return "red";
+        }
+
+        // SNR에 맞는 색상의 마커 아이콘 생성
+        function createMarkerIcon(color) {
+            return L.divIcon({
+                className: 'custom-icon',
+                html: `<div style="background-color: ${color}; width: 20px; height: 20px; border-radius: 50%;"></div>`,
+                iconSize: [20, 20]
+            });
+        }
+
+        function updateLocation() { // 컴퓨터로 접속했을때 (서버에서 받을 위경도가 없을때)
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(position => {
+                    let lat = position.coords.latitude;
+                    let lon = position.coords.longitude;
+                    let alt = position.coords.altitude || 0;  // 고도 값 받기, 없으면 0으로 설정
+                    
+                    console.log("📌 현재 위치:", lat, lon, alt);
+                    updateMarker(lat,lon);
+                });
+            } else {
+                alert("이 브라우저는 GPS를 지원하지 않습니다.");
+            }
+        }
+
+        setInterval(updateLocation, 3000);
+    </script>
+</body>
+</html>

--- a/Flask_GPS/gps.py
+++ b/Flask_GPS/gps.py
@@ -1,0 +1,47 @@
+from flask import Flask, request, render_template, jsonify
+from flask_cors import CORS
+from flask import send_from_directory
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/.well-known/acme-challenge/<filename>')
+def letsencrypt_challenge(filename):
+    return send_from_directory('static/.well-known/acme-challenge', filename)
+
+gps_data = {"latitude": None, "longitude": None, "snr": None}  # GPS + SNR 데이터 저장
+
+@app.route('/')
+def index():
+    return render_template('test.html')  # templates 폴더에 index.html 파일 제공
+
+@app.route('/gps', methods=['POST'])
+def receive_gps():
+    global gps_data
+    data = request.get_json()
+    
+    gps_data["latitude"] = data.get("latitude")
+    gps_data["longitude"] = data.get("longitude")
+    gps_data["snr"] = data.get("snr")  # SNR 값 저장
+    
+    print(f"📌 새로운 GPS 데이터 수신: {gps_data}")
+    return jsonify({"status": "success", "received": gps_data})
+
+@app.route('/gps', methods=['GET'])
+def get_gps():
+    # GPS 데이터가 없을 경우 기본값을 반환하도록 설정 (디버깅용) 
+    if gps_data["latitude"] is None or gps_data["longitude"] is None:
+        return jsonify({"status": "error", "message": "GPS connect x "}), 400
+    
+    return jsonify({
+        "status": "success",
+        "latitude": gps_data["latitude"],
+        "longitude": gps_data["longitude"],
+        "snr": gps_data["snr"]
+    })
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=443, ssl_context=(
+        'C:\\Users\\seok6\\OneDrive\\Desktop\\demo\\src\\main\\resources\\inhamap.n-e.kr-crt.pem', 
+        'C:\\Users\\seok6\\OneDrive\\Desktop\\demo\\src\\main\\resources\\inhamap.n-e.kr-key.pem'
+    )) 

--- a/capstone/.gitignore
+++ b/capstone/.gitignore
@@ -61,3 +61,17 @@ application.properties
 application.yml
 application-dev.properties
 application-prod.properties
+
+# Flask
+Flask_GPS/**/*.pem
+Flask_GPS/*.pem
+Flask_GPS/__pycache__/
+Flask_GPS/venv/
+Flask_GPS/.venv/
+Flask_GPS/*.pyc
+
+# Python 공통
+*.pyc
+*.db
+instance/
+*.sqlite3


### PR DESCRIPTION
## 작업내용
### 서버 관련
Flask 기반의 실시간 GNSS 위치 시각화 서버를 `Flask_GPS` 디렉토리 생성
gps.py를 통해 GPS 좌표 및 SNR 데이터를 수신 및 지도 상에 시각화
Flask 기반 앱 용 백엔드 서버 구현
GPS 및 SNR 데이터의 GET/POST 처리
HTTPS 배포를 위한 인증서 설정 포함 (포트 443)

### 템플릿 관련
Leaflet을 이용한 지도 시각화 구현
서버로부터 수신한 GPS 좌표에 따라 마커 표시
SNR 수치에 따라 마커 색상(초록, 주황, 빨강) 자동 구분
GPS 좌표가 없을 경우 브라우저의 위치정보 API를 통해 대체 위치 표시