### PR TITLE
[Refactor] 도로 중심점을 백엔드에서 연결된 중심점 쌍만 Polyline으로 시각화

### DIFF
--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -56,27 +56,37 @@ function App() {
             map: map,
             title: `도로 중심점 ${center.id}`,
             icon: {
-              url: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png", // 건물 출입구랑 안겹치게 파란 마커 사용 
+              url: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png",
             },
           });
         });
-
-        const lineCoordinates = data.map((center) => ({
-          lat: center.latitude,
-          lng: center.longitude,
-        }));
-
-        const polyline = new window.google.maps.Polyline({
-          path: lineCoordinates,
-          geodesic: true,
-          strokeColor: "#0000FF", 
-          strokeOpacity: 0.8,
-          strokeWeight: 4,
-        });
-        polyline.setMap(map);
       })
       .catch((error) => {
         console.error("Error loading road centers:", error);
+      });
+
+    // 원하는 선만 표시하는 로직 
+    fetch("http://localhost:8080/api/road-links")
+      .then((res) => res.json())
+      .then((links) => {
+        links.forEach((link) => {
+          const path = [
+            { lat: link.from.latitude, lng: link.from.longitude },
+            { lat: link.to.latitude, lng: link.to.longitude },
+          ];
+
+          new window.google.maps.Polyline({
+            path: path,
+            geodesic: true,
+            strokeColor: "#00BFFF",
+            strokeOpacity: 1.0,
+            strokeWeight: 4,
+            map: map,
+          });
+        });
+      })
+      .catch((error) => {
+        console.error("Error loading road links:", error);
       });
   }, [map]);
 


### PR DESCRIPTION
## 목적
- 백엔드에서 연결된 도로 중심점 쌍을 `/api/road-links`로 받아와 Google Maps에서 Polyline을 통해 경로를 시각화

- 기존에는 모든 도로 중심점을 자동으로 이어 선을 그렸지만
이제는 원하는 도로 중심점 연결만 정확하게 선으로 표시하도록 구현 

---

## 작업내용 

- `GET /api/road-links` 호출하여 연결된 중심점 쌍 데이터 fetch
- Polyline을 사용해 각 연결된 쌍만 선으로 시각화

---

## ✅ 테스트 결과

- 연결된 쌍만 정확히 지도 위에 선으로 표현됨
- `GET /api/road-links` 응답 기반으로 선 생성됨
- Google Maps 상에서 경로 시각화 기능 정상 작동 확인

![화면 캡처 2025-04-24 135535](https://github.com/user-attachments/assets/dea3cf7e-987f-4350-87f9-d39c32f2f053)
