### PR TITLE
[Refactor] Flask GPS 실시간 연동 및 지도 마커 표시 리팩토링

### DIFF
--- a/Flask_GPS/templates/gnss.html
+++ b/Flask_GPS/templates/gnss.html
@@ -17,6 +17,7 @@
     <div id="map"></div>
 
     <script>
+        const FLASK_URL = "https://127.0.0.1:443/gps";
         // 1️⃣ Leaflet을 사용하여 지도 생성
         var map = L.map('map').setView([37.5665, 126.9780], 13);
 
@@ -28,40 +29,74 @@
         // 3️⃣ 추정된 GPS 좌표를 사용해 마커 생성
         var marker;
 
-        function  getData() {
-            fetch("https://inhamap.n-e.kr/gps",{
-                method: "GET"
-            })
+        function getData() {
+            fetch(FLASK_URL, { method: "GET" })
             .then(response => response.json())
             .then(data => {
-                // 추정된 좌표가 서버에서 받아졌을 때
                 if (data.status === "success") {
-                    let Lat = data.latitude;
-                    let Lon = data.longitude;
+                    let lat = data.latitude;
+                    let lon = data.longitude;
                     let snr = data.snr;
-
-                    console.log("📌 GPS 데이터:", Lat, Lon, snr);
-
-                    // 6️⃣ 추정된 GPS 좌표로 마커 위치 업데이트
-                    updateMarker(Lat, Lon, snr);
-                }
-                else{
-                    updateLocation();
+                    console.log("📡 Flask에서 수신한 위치:", lat, lon, snr);
+                    updateMarker(lat, lon, snr);
+                } else {
+                    console.warn("⚠️ 서버 위치 없음 → fallback");
+                    updateLocation();  // 브라우저 GPS fallback
                 }
             })
-            .catch(error => console.error("❌ 에러 발생:", error));  
+            .catch(error => {
+                console.error("❌ Flask 서버 요청 실패:", error);
+                updateLocation();  
+            });
         }
 
-        function updateMarker(lat, lon,snr) {
-            let markerColor = getColorBySNR(snr);
-            if (marker) {
-                // 기존 마커가 있으면 위치 업데이트
-                marker.setLatLng([lat, lon]).setIcon(createMarkerIcon(markerColor));
+        function updateLocation() {
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(position => {
+                    const lat = position.coords.latitude;
+                    const lon = position.coords.longitude;
+                    const snr = 25;  // 기본값 
+                    console.log("📍 브라우저 위치:", lat, lon);
+                    updateMarker(lat, lon, snr);
+        
+                    // 서버로 현재 위치 전송 (실시간 전송)
+                    fetch(FLASK_URL, {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify({
+                            latitude: lat,
+                            longitude: lon,
+                            snr: snr
+                        })
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        console.log("✅ 서버에 위치 전송 성공:", data);
+                    })
+                    .catch(error => {
+                        console.error("❌ 서버 전송 실패:", error);
+                    });
+        
+                }, error => {
+                    console.warn("❗ 위치 접근 실패:", error);
+                });
             } else {
-                // 없으면 새로운 마커 추가
-                marker = L.marker([lat, lon], { icon: createMarkerIcon(markerColor) }).addTo(map);
+                alert("이 브라우저는 GPS를 지원하지 않습니다.");
             }
-            map.setView([lat, lon], 13);  // 지도 중심을 추정된 좌표로 설정
+        }
+
+        function updateMarker(lat, lon, snr) {
+            let color = getColorBySNR(snr);
+            if (marker) {
+                marker.setLatLng([lat, lon]).setIcon(createMarkerIcon(color));
+            } else {
+                marker = L.marker([lat, lon], {
+                    icon: createMarkerIcon(color)
+                }).addTo(map);
+            }
+            map.setView([lat, lon], 13);
         }
 
         function getColorBySNR(snr) {
@@ -79,22 +114,7 @@
             });
         }
 
-        function updateLocation() { // 컴퓨터로 접속했을때 (서버에서 받을 위경도가 없을때)
-            if (navigator.geolocation) {
-                navigator.geolocation.getCurrentPosition(position => {
-                    let lat = position.coords.latitude;
-                    let lon = position.coords.longitude;
-                    let alt = position.coords.altitude || 0;  // 고도 값 받기, 없으면 0으로 설정
-                    
-                    console.log("📌 현재 위치:", lat, lon, alt);
-                    updateMarker(lat,lon);
-                });
-            } else {
-                alert("이 브라우저는 GPS를 지원하지 않습니다.");
-            }
-        }
-
-        setInterval(updateLocation, 3000);
+        setInterval(getData, 3000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## 목적
- 기존 브라우저의 `Geolocation API`를 통해 지도에만 위치를 표시하던 구조에서,
  **Flask → Spring → Front 간 실시간 GPS 연동**이 가능하도록 리팩토링 시행 


## 작업 내용 

### 1. `gnss.html` 변경
- 기존에는 단순히 `navigator.geolocation`으로 위치만 표시
- → 이제 위치 정보를 Flask 서버로 POST 전송 (`/gps`)
- → Flask는 이를 저장하고, 다른 클라이언트 요청에 GET으로 응답
- → GET `/gps` → 성공 시 마커 업데이트, 실패 시 fallback 으로 브라우저 위치 사용

### 2. Flask 서버 역할 강화
- GPS 데이터를 `POST /gps`로 수신하고, `GET /gps` 요청에 대해 최신 데이터를 응답
- 인증서 적용된 HTTPS 환경에서도 WebClient가 통신 가능하도록 설정

### 3. Spring 서버 연동
- `WebClient` 기반으로 Flask 서버와 HTTPS 통신
- 실시간으로 Flask의 `/gps`에서 데이터 가져와 DTO에 매핑시킴


## ✅ 테스트 결과

- 브라우저 접속 시 `gps.py`에서 마커가 지속적으로 업데이트됨 확인
- POST → GET 흐름이 정상적으로 작동하며, 최초 데이터 없을 때 fallback도 정상적으로 동작함 

![화면 캡처 2025-05-05 223323](https://github.com/user-attachments/assets/b7f7aba5-dacc-400c-b0d8-f95b41b9de1f)
