### PR TITLE
[Feat] 실배포 환경 도메인 연동 (https 적용)

### DIFF
--- a/Flask_GPS/gps.py
+++ b/Flask_GPS/gps.py
@@ -5,8 +5,8 @@ app = Flask(__name__)
 CORS(app)
 
 # 인증서 파일 경로
-CERT_FILE = 'certs/inhamap.n-e.kr-crt.pem'
-KEY_FILE = 'certs/inhamap.n-e.kr-key.pem'
+CERT_FILE = '/etc/letsencrypt/live/inhacapstone.p-e.kr/fullchain.pem'
+KEY_FILE = '/etc/letsencrypt/live/inhacapstone.p-e.kr/privkey.pem'
 
 gps_data = {"latitude": None, "longitude": None, "snr": None}
 

--- a/Flask_GPS/templates/gnss.html
+++ b/Flask_GPS/templates/gnss.html
@@ -17,7 +17,7 @@
     <div id="map"></div>
 
     <script>
-        const FLASK_URL = "https://127.0.0.1:443/gps";
+        const FLASK_URL = "https://inhacapstone.p-e.kr/gps"; // 실제 배포 url 
         // 1️⃣ Leaflet을 사용하여 지도 생성
         var map = L.map('map').setView([37.5665, 126.9780], 13);
 


### PR DESCRIPTION
## 작업 내용
- 기존 `localhost` 기반 테스트 주소를 실배포용 도메인(`https://inhacapstone.p-e.kr/gps`)으로 변경
- 실제 운영 서버에서 위치 데이터를 수신 및 시각화 가능하도록 Leaflet 연동
- 앱에서 받아오는 실시간 위치를 웹으로 넘길수 있도록 실 배포 서버로 url 변경 

## 테스트
- 실제 서버에서 Flask 서버 실행 중임 (tmux로 백그라운드 유지)
- `gnss.html` 로딩 시 브라우저에서 위치 수신 → 서버로 POST 
