### PR TITLE
[Feat]: 출입구 이름 검색 기능 연동 및 최단 경로 자동 탐색 구현

### DIFF
--- a/capstone/src/App.jsx
+++ b/capstone/src/App.jsx
@@ -2,12 +2,14 @@ import React from "react";
 import "./styles/App.css";
 import MapContainer from "./components/MapContainer";
 import SearchPanel from "./components/SearchPanel";
+import { useState } from "react";
 
 function App() {
+  const [selectedDestinationId, setSelectedDestinationId] = useState(null);
   return (
     <div className="app-container">
-      <SearchPanel />
-      <MapContainer />
+      <SearchPanel setSelectedDestinationId={setSelectedDestinationId} />
+      <MapContainer selectedDestinationId={selectedDestinationId} />
     </div>
   );
 }

--- a/capstone/src/components/MapContainer.jsx
+++ b/capstone/src/components/MapContainer.jsx
@@ -15,7 +15,7 @@ function MapContainer() {
   const currentMarkerRef = useRef(null);
 
   
-  const [selectedDestinationId, setSelectedDestinationId] = useState(15);
+  const [selectedDestinationId, setSelectedDestinationId] = useState(null);
 
   useEffect(() => {
     if (window.google && window.google.maps) {
@@ -186,7 +186,7 @@ function MapContainer() {
 
   // 최단경로 (현재 위치 → 선택한 목적지까지)
   useEffect(() => {
-    if (!map || !selectedDestinationId) return;
+    if (!map || !selectedDestinationId || !currentLocation) return;
 
     if (pathPolyline) {
       pathPolyline.setMap(null);
@@ -221,7 +221,7 @@ function MapContainer() {
       .catch((err) => {
         console.error("❌ 최단 경로 호출 실패", err);
       });
-  }, [map, selectedDestinationId]);
+  }, [map, selectedDestinationId,currentLocation]);
 
   return (
     <div ref={mapRef} className="map-container"></div>

--- a/capstone/src/components/MapContainer.jsx
+++ b/capstone/src/components/MapContainer.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-function MapContainer() {
+function MapContainer({ selectedDestinationId }) {
   const mapRef = useRef(null);
   const [map, setMap] = useState(null);
 
@@ -15,7 +15,7 @@ function MapContainer() {
   const currentMarkerRef = useRef(null);
 
   
-  const [selectedDestinationId, setSelectedDestinationId] = useState(null);
+  // const [selectedDestinationId, setSelectedDestinationId] = useState(null);
 
   useEffect(() => {
     if (window.google && window.google.maps) {

--- a/capstone/src/components/SearchPanel.jsx
+++ b/capstone/src/components/SearchPanel.jsx
@@ -1,10 +1,32 @@
 import React, { useState } from "react";
 
-function SearchPanel() {
+function SearchPanel({ setSelectedDestinationId }) {
   const [searchQuery, setSearchQuery] = useState("");
 
   const handleSearch = () => {
-    alert(`검색 예정: ${searchQuery}`);
+    if (!searchQuery.trim()) {
+      alert("출입구 이름을 입력해주세요.");
+      return;
+    }
+
+    // 이름으로 gate Id 검색
+    fetch(`http://localhost:8080/api/navigation/gate-id-by-name?name=${encodeURIComponent(searchQuery)}`)
+      .then(res => {
+        if (!res.ok) throw new Error("출입구 이름을 찾을 수 없습니다.");
+        return res.json();
+      })
+      .then(gateId => {
+        return fetch(`http://localhost:8080/api/navigation/gate-to-road-center?gateId=${gateId}`);
+      })
+      .then(res => res.json())
+      .then(centerId => {
+        console.log("목적지 도로 중심 ID: ", centerId);
+        setSelectedDestinationId(centerId); 
+      })
+      .catch(err => {
+        console.error("검색 실패: ", err);
+        alert("검색 실패: 해당 출입구 이름이 존재하지 않거나 연결이 없습니다.");
+      });
   };
 
   return (
@@ -12,7 +34,7 @@ function SearchPanel() {
       <h2>🔍 목적지 검색</h2>
       <input
         type="text"
-        placeholder="예: 인하대학교 본관"
+        placeholder="예: 인하대학교 4호관 남쪽 출입구"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />
@@ -22,3 +44,4 @@ function SearchPanel() {
 }
 
 export default SearchPanel;
+


### PR DESCRIPTION
### 작업내용

- 검색창에 출입구 이름을 입력하면, 해당 출입구를 목적지로 설정 후 최단 경로를 지도에 표시하는 기능 추가
- SearchPanel에서 사용자가 입력한 출입구 이름을 기반으로 경로 탐색 수행:
  1. /api/navigation/gate-id-by-name API로 GatePoint ID 조회
  2. /api/navigation/gate-to-road-center  API로 도로 중심점 ID 조회
  3. selectedDestinationId 설정을 통해 자동으로 지도에 경로 폴리라인 렌더링


###  테스트 결과
1. 좌측 검색창에 출입구 이름 입력 (예: 인하대학교 2호관 동쪽 출입구)
3. 검색 성공 시 경로가 지도에 표시
4. 등록되지 않은 이름 검색 시 예외 처리됨

